### PR TITLE
Update smtp.lib.php - define date to descrease SPAM score

### DIFF
--- a/include/smtp/smtp.lib.php
+++ b/include/smtp/smtp.lib.php
@@ -87,6 +87,7 @@ class smtp
 	*/
 	function smtp()
 	{
+		$this->_add_hdr('Date', sprintf(date(DateTime::RFC2822)));
 		$this->_add_hdr('X-Mailer', sprintf('LAGNUT-SMTP/%s', $this->_version));
 		$this->_add_hdr('User-Agent', sprintf('LAGNUT-SMTP/%s', $this->_version));
 		$this->_add_hdr('MIME-Version', '1.0');


### PR DESCRIPTION
This modification decreases the SPAM score given by SpamAssassin from 1.4 to 0.4 by defining Date in header.
Before: 1.4 MISSING_DATE           Missing Date: header
After: 0.4 INVALID_DATE           Invalid Date: header (not RFC 2822)